### PR TITLE
Implement patch_get_versions

### DIFF
--- a/payroll_indonesia/__init__.py
+++ b/payroll_indonesia/__init__.py
@@ -1,3 +1,34 @@
-# -*- coding: utf-8 -*-
-# Hanya definisikan versi, tidak ada kode lain
+"""Top level package for Payroll Indonesia."""
+
 __version__ = "0.0.1"
+
+__all__ = ["patch_get_versions"]
+
+
+def patch_get_versions() -> None:
+    """Patch ``frappe.get_versions`` to include this package's version.
+
+    The original :func:`frappe.get_versions` returns a mapping of installed app
+    names to their versions.  This helper wraps that function so the returned
+    mapping always contains ``{"payroll_indonesia": __version__}``.
+    """
+
+    try:
+        import frappe
+    except Exception:  # pragma: no cover - frappe isn't installed during tests
+        return
+
+    if getattr(frappe.get_versions, "_patched_for_payroll_indonesia", False):
+        return
+
+    original = frappe.get_versions
+
+    def _wrapped_get_versions(*args, **kwargs):
+        versions = original(*args, **kwargs)
+        if isinstance(versions, dict):
+            versions.setdefault("payroll_indonesia", __version__)
+        return versions
+
+    _wrapped_get_versions._patched_for_payroll_indonesia = True  # type: ignore[attr-defined]
+    frappe.get_versions = _wrapped_get_versions
+

--- a/payroll_indonesia/payroll_indonesia/tests/test_patch_get_versions.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_patch_get_versions.py
@@ -1,0 +1,30 @@
+import sys
+import types
+import importlib
+
+
+def test_patch_get_versions_injects_version():
+    # create a minimal frappe stub
+    frappe = types.ModuleType("frappe")
+
+    def get_versions():
+        return {"frappe": "1.0"}
+
+    frappe.get_versions = get_versions
+    sys.modules["frappe"] = frappe
+
+    module = importlib.import_module("payroll_indonesia")
+
+    module.patch_get_versions()
+    patched = frappe.get_versions
+
+    versions = patched()
+    assert versions["frappe"] == "1.0"
+    assert versions["payroll_indonesia"] == module.__version__
+
+    # ensure idempotent
+    module.patch_get_versions()
+    assert frappe.get_versions is patched
+    assert frappe.get_versions()["payroll_indonesia"] == module.__version__
+
+    del sys.modules["frappe"]


### PR DESCRIPTION
## Summary
- expose new patch_get_versions helper that injects Payroll Indonesia version into `frappe.get_versions`
- add unit test verifying the behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773205d04c833393948fa27fb72176