### PR TITLE
Add take-home calculator helper

### DIFF
--- a/payroll_indonesia/override/salary_slip/__init__.py
+++ b/payroll_indonesia/override/salary_slip/__init__.py
@@ -8,9 +8,11 @@
 from .controller import IndonesiaPayrollSalarySlip  # noqa: F401
 from .bpjs_calculator import calculate_bpjs  # noqa: F401
 from .salary_utils import calculate_ytd_and_ytm  # noqa: F401
+from .take_home_calculator import calculate_take_home_and_bpjs  # noqa: F401
 
 __all__ = [
     "IndonesiaPayrollSalarySlip",
     "calculate_bpjs",
     "calculate_ytd_and_ytm",
+    "calculate_take_home_and_bpjs",
 ]

--- a/payroll_indonesia/override/salary_slip/bpjs_calculator.py
+++ b/payroll_indonesia/override/salary_slip/bpjs_calculator.py
@@ -16,6 +16,7 @@ from frappe.utils import flt, cint
 
 from payroll_indonesia.frappe_helpers import logger
 from payroll_indonesia.config.config import get_live_config, get_component_tax_effect
+from .take_home_calculator import calculate_take_home_and_bpjs
 from payroll_indonesia.constants import (
     DEFAULT_UMR,
     BPJS_KESEHATAN_EMPLOYEE_PERCENT,
@@ -465,47 +466,48 @@ def calculate_components(slip: Any) -> Dict[str, float]:
             percentages["jkm"] = BPJS_JKM_PERCENT
             logger.warning(f"BPJS JKM percent not found. Using default: {percentages['jkm']}%")
 
-        # Calculate each component
-        # Use existing value if available, otherwise calculate
-        if not kesehatan_employee_comp:
-            result["kesehatan_employee"] = calculate_bpjs(
-                base_salary, percentages["kesehatan_emp"], max_salary=kesehatan_max
-            )
+        # Calculate each component using helper
+        calc_rates = {
+            "kesehatan_employee_percent": percentages["kesehatan_emp"],
+            "kesehatan_employer_percent": percentages["kesehatan_com"],
+            "jht_employee_percent": percentages["jht_emp"],
+            "jht_employer_percent": percentages["jht_com"],
+            "jp_employee_percent": percentages["jp_emp"],
+            "jp_employer_percent": percentages["jp_com"],
+            "kesehatan_max_salary": kesehatan_max,
+            "jp_max_salary": jp_max,
+            "jkk_percent": percentages["jkk"],
+            "jkm_percent": percentages["jkm"],
+        }
 
-        result["kesehatan_employer"] = calculate_bpjs(
-            base_salary, percentages["kesehatan_com"], max_salary=kesehatan_max
-        )
+        calc_result = calculate_take_home_and_bpjs(base_salary, calc_rates)
 
-        if not jht_employee_comp:
-            result["jht_employee"] = calculate_bpjs(base_salary, percentages["jht_emp"])
+        # Use existing component amounts if present
+        if kesehatan_employee_comp:
+            result["kesehatan_employee"] = deduction_amounts[kesehatan_employee_comp]
+        else:
+            result["kesehatan_employee"] = calc_result["kesehatan_employee"]
 
-        result["jht_employer"] = calculate_bpjs(base_salary, percentages["jht_com"])
+        result["kesehatan_employer"] = calc_result["kesehatan_employer"]
 
-        if not jp_employee_comp:
-            result["jp_employee"] = calculate_bpjs(
-                base_salary, percentages["jp_emp"], max_salary=jp_max
-            )
+        if jht_employee_comp:
+            result["jht_employee"] = deduction_amounts[jht_employee_comp]
+        else:
+            result["jht_employee"] = calc_result["jht_employee"]
 
-        result["jp_employer"] = calculate_bpjs(
-            base_salary, percentages["jp_com"], max_salary=jp_max
-        )
+        result["jht_employer"] = calc_result["jht_employer"]
 
-        result["jkk"] = calculate_bpjs(base_salary, percentages["jkk"])
+        if jp_employee_comp:
+            result["jp_employee"] = deduction_amounts[jp_employee_comp]
+        else:
+            result["jp_employee"] = calc_result["jp_employee"]
 
-        result["jkm"] = calculate_bpjs(base_salary, percentages["jkm"])
+        result["jp_employer"] = calc_result["jp_employer"]
+        result["jkk"] = calc_result["jkk"]
+        result["jkm"] = calc_result["jkm"]
 
-        # Calculate totals
-        result["total_employee"] = (
-            result["kesehatan_employee"] + result["jht_employee"] + result["jp_employee"]
-        )
-
-        result["total_employer"] = (
-            result["kesehatan_employer"]
-            + result["jht_employer"]
-            + result["jp_employer"]
-            + result["jkk"]
-            + result["jkm"]
-        )
+        result["total_employee"] = calc_result["employee_total"]
+        result["total_employer"] = calc_result["employer_total"]
 
         employee_id = getattr(slip, "employee", "unknown")
         logger.debug(f"BPJS calculation for {employee_id}: {result}")

--- a/payroll_indonesia/override/salary_slip/take_home_calculator.py
+++ b/payroll_indonesia/override/salary_slip/take_home_calculator.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Utility to compute BPJS deductions, employer contributions and take-home pay."""
+
+from typing import Dict, Any
+
+from frappe.utils import flt
+
+from payroll_indonesia.override.salary_slip.bpjs_calculator import calculate_bpjs
+from payroll_indonesia.constants import DEFAULT_BPJS_RATES
+
+__all__ = ["calculate_take_home_and_bpjs"]
+
+
+def calculate_take_home_and_bpjs(
+    gross_salary: float,
+    bpjs_rates: Dict[str, Any] | None = None,
+) -> Dict[str, float]:
+    """Return totals for BPJS and take-home pay given salary and rate settings."""
+    try:
+        rates = {**DEFAULT_BPJS_RATES}
+        if bpjs_rates:
+            rates.update({k: flt(v) for k, v in bpjs_rates.items() if v is not None})
+
+        base = flt(gross_salary)
+        # Employee portions
+        kes_emp = calculate_bpjs(
+            base,
+            rates["kesehatan_employee_percent"],
+            max_salary=rates.get("kesehatan_max_salary"),
+        )
+        jht_emp = calculate_bpjs(base, rates["jht_employee_percent"])
+        jp_emp = calculate_bpjs(
+            base,
+            rates["jp_employee_percent"],
+            max_salary=rates.get("jp_max_salary"),
+        )
+
+        # Employer portions
+        kes_com = calculate_bpjs(
+            base,
+            rates["kesehatan_employer_percent"],
+            max_salary=rates.get("kesehatan_max_salary"),
+        )
+        jht_com = calculate_bpjs(base, rates["jht_employer_percent"])
+        jp_com = calculate_bpjs(
+            base,
+            rates["jp_employer_percent"],
+            max_salary=rates.get("jp_max_salary"),
+        )
+        jkk = calculate_bpjs(base, rates["jkk_percent"])
+        jkm = calculate_bpjs(base, rates["jkm_percent"])
+
+        employee_total = kes_emp + jht_emp + jp_emp
+        employer_total = kes_com + jht_com + jp_com + jkk + jkm
+
+        take_home = base - employee_total
+        taxable_base = base - employee_total
+
+        return {
+            "employee_total": float(employee_total),
+            "employer_total": float(employer_total),
+            "take_home_pay": float(take_home),
+            "taxable_base": float(taxable_base),
+            "kesehatan_employee": float(kes_emp),
+            "jht_employee": float(jht_emp),
+            "jp_employee": float(jp_emp),
+            "kesehatan_employer": float(kes_com),
+            "jht_employer": float(jht_com),
+            "jp_employer": float(jp_com),
+            "jkk": float(jkk),
+            "jkm": float(jkm),
+        }
+    except Exception:
+        return {
+            "employee_total": 0.0,
+            "employer_total": 0.0,
+            "take_home_pay": 0.0,
+            "taxable_base": 0.0,
+        }

--- a/payroll_indonesia/override/salary_slip_functions.py
+++ b/payroll_indonesia/override/salary_slip_functions.py
@@ -34,6 +34,7 @@ from payroll_indonesia.override.salary_slip.controller import (
     calculate_taxable_earnings,
     get_bpjs_deductions,
 )
+from payroll_indonesia.override.salary_slip.take_home_calculator import calculate_take_home_and_bpjs
 from payroll_indonesia.frappe_helpers import logger
 from payroll_indonesia.payroll_indonesia import utils
 
@@ -431,7 +432,9 @@ def _update_custom_fields(doc):
             gross_income += tax_components["totals"].get(NATURA_OBJEK_EFFECT, 0)
             deductions = tax_components["totals"].get(TAX_DEDUCTION_EFFECT, 0)
 
-            netto = gross_income - deductions
+            # Calculate take home and taxable base via helper
+            helper_res = calculate_take_home_and_bpjs(getattr(doc, "gross_pay", 0))
+            netto = helper_res["take_home_pay"]
 
             if hasattr(doc, "netto"):
                 doc.netto = netto

--- a/payroll_indonesia/payroll_indonesia/tests/test_take_home_calculator.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_take_home_calculator.py
@@ -1,0 +1,48 @@
+import sys
+import types
+
+
+def test_take_home_calculator_basic():
+    # stub frappe utils with minimal flt function
+    frappe = types.ModuleType("frappe")
+    frappe.utils = types.ModuleType("frappe.utils")
+    frappe.utils.flt = float
+    frappe._ = lambda x: x
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    # stub override package to avoid importing payroll_entry
+    override_pkg = types.ModuleType("payroll_indonesia.override")
+    salary_slip_pkg = types.ModuleType("payroll_indonesia.override.salary_slip")
+    salary_slip_pkg.__path__ = []
+    override_pkg.salary_slip = salary_slip_pkg
+    sys.modules["payroll_indonesia.override"] = override_pkg
+    sys.modules["payroll_indonesia.override.salary_slip"] = salary_slip_pkg
+
+    # stub bpjs calculator to avoid full dependency
+    bpjs_stub = types.ModuleType("payroll_indonesia.override.salary_slip.bpjs_calculator")
+
+    def simple_calc(base, rate, max_salary=None):
+        if max_salary and base > max_salary:
+            base = max_salary
+        return round(base * rate / 100.0)
+
+    bpjs_stub.calculate_bpjs = simple_calc
+    sys.modules[
+        "payroll_indonesia.override.salary_slip.bpjs_calculator"
+    ] = bpjs_stub
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "take_home_calculator",
+        "payroll_indonesia/override/salary_slip/take_home_calculator.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    res = mod.calculate_take_home_and_bpjs(10_000_000)
+
+    assert res["employee_total"] == 390776
+    assert res["employer_total"] == 1005552
+    assert res["take_home_pay"] == 10_000_000 - 390776
+    assert res["taxable_base"] == 10_000_000 - 390776


### PR DESCRIPTION
## Summary
- implement `calculate_take_home_and_bpjs` helper
- integrate helper with BPJS calculator and salary slip functions
- expose helper from package
- test take-home calculator logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877320820e0833394a5095a5f7053a3