### PR TITLE
Auto create salary slips on payroll entry submit

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -57,6 +57,9 @@ doc_events = {
         "after_insert": "payroll_indonesia.fixtures.setup.setup_company_accounts",
         "on_update": "payroll_indonesia.fixtures.setup.setup_company_accounts",
     },
+    "Payroll Entry": {
+        "on_submit": "payroll_indonesia.override.payroll_entry_functions.create_salary_slips",
+    },
     "Payment Entry": {
         "on_submit": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.payment_hooks.on_payment_entry_submit",
     },

--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -252,6 +252,9 @@ class CustomPayrollEntry(Document):
         """Ensure status is set to Submitted after submission."""
         try:
             self.db_set("status", "Submitted")
+            # Automatically create and submit salary slips for this payroll entry
+            from .payroll_entry_functions import create_salary_slips
+            create_salary_slips(self)
             logger.debug(f"Payroll entry {getattr(self, 'name', 'unknown')} marked as Submitted")
         except Exception as e:
             logger.exception(f"Error in on_submit: {str(e)}")

--- a/payroll_indonesia/override/payroll_entry_functions.py
+++ b/payroll_indonesia/override/payroll_entry_functions.py
@@ -302,3 +302,35 @@ def _validate_component_tax_effects(doc):
     
     except Exception as e:
         logger.exception(f"Error validating component tax effects: {str(e)}")
+
+
+def create_salary_slips(doc, method=None, enqueue=False):
+    """Create and submit salary slips for the given payroll entry."""
+    try:
+        from hrms.payroll.doctype.payroll_entry.payroll_entry import (
+            make_salary_slips,
+            enqueue_make_salary_slips,
+        )
+    except Exception:
+        logger.exception("Could not import salary slip creation utilities")
+        return []
+
+    try:
+        create_fn = enqueue_make_salary_slips if enqueue else make_salary_slips
+        slip_names = create_fn(doc.name)
+        if isinstance(slip_names, dict):
+            slip_names = slip_names.get("salary_slips") or []
+
+        for name in slip_names:
+            try:
+                slip = frappe.get_doc("Salary Slip", name)
+                if getattr(slip, "docstatus", 0) == 0 and hasattr(slip, "submit"):
+                    slip.submit()
+            except Exception:
+                logger.exception(f"Failed to submit Salary Slip {name}")
+
+        return slip_names
+
+    except Exception as e:
+        logger.exception(f"Error creating salary slips: {str(e)}")
+        return []

--- a/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
@@ -1,0 +1,95 @@
+import sys
+import types
+import importlib.util
+
+
+def test_payroll_entry_creates_salary_slips(monkeypatch):
+    # stub frappe module
+    frappe = types.ModuleType("frappe")
+    frappe.db = types.SimpleNamespace(set_value=lambda *a, **k: None)
+    frappe._ = lambda x: x
+    frappe.utils = types.ModuleType("frappe.utils")
+    frappe.utils.flt = float
+    frappe.utils.cint = int
+    frappe.utils.getdate = lambda *a, **k: None
+    frappe.utils.add_days = lambda d, n=0: d
+    frappe.utils.add_months = lambda d, m=0: d
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    # minimal Document class
+    model_module = types.ModuleType("frappe.model")
+    document_module = types.ModuleType("frappe.model.document")
+
+    class Document:
+        def db_set(self, field, value):
+            setattr(self, field, value)
+        def submit(self):
+            if hasattr(self, "before_submit"):
+                self.before_submit()
+            if hasattr(self, "on_submit"):
+                self.on_submit()
+            if hasattr(self, "after_submit"):
+                self.after_submit()
+            self.docstatus = 1
+
+    document_module.Document = Document
+    sys.modules["frappe.model"] = model_module
+    sys.modules["frappe.model.document"] = document_module
+
+    # store salary slip docs
+    slip_store = {}
+    def get_doc(doctype, name=None):
+        if doctype == "Salary Slip":
+            if name not in slip_store:
+                slip = Document()
+                slip.name = name
+                slip.docstatus = 0
+                slip_store[name] = slip
+            return slip_store[name]
+        raise KeyError(doctype)
+    frappe.get_doc = get_doc
+
+    # stub hrms payroll entry functions
+    hrms_mod = types.ModuleType("hrms.payroll.doctype.payroll_entry.payroll_entry")
+    def make_salary_slips(payroll_entry_name):
+        return [f"SS-{i}" for i, _ in enumerate(entry.employees)]
+    hrms_mod.make_salary_slips = make_salary_slips
+    hrms_mod.enqueue_make_salary_slips = make_salary_slips
+    sys.modules["hrms"] = types.ModuleType("hrms")
+    sys.modules["hrms.payroll"] = types.ModuleType("hrms.payroll")
+    sys.modules["hrms.payroll.doctype"] = types.ModuleType("hrms.payroll.doctype")
+    sys.modules["hrms.payroll.doctype.payroll_entry"] = types.ModuleType("hrms.payroll.doctype.payroll_entry")
+    sys.modules["hrms.payroll.doctype.payroll_entry.payroll_entry"] = hrms_mod
+
+    # stub logger
+    logger = types.SimpleNamespace(debug=lambda *a, **k: None, exception=lambda *a, **k: None)
+    sys.modules["payroll_indonesia.frappe_helpers"] = types.SimpleNamespace(logger=logger)
+
+    # import modules under test
+    import importlib.util
+    # load helper module to satisfy relative import
+    func_spec = importlib.util.spec_from_file_location(
+        "payroll_indonesia.override.payroll_entry_functions",
+        "payroll_indonesia/override/payroll_entry_functions.py",
+    )
+    funcs = importlib.util.module_from_spec(func_spec)
+    func_spec.loader.exec_module(funcs)
+    sys.modules["payroll_indonesia.override.payroll_entry_functions"] = funcs
+
+    spec = importlib.util.spec_from_file_location(
+        "payroll_indonesia.override.payroll_entry",
+        "payroll_indonesia/override/payroll_entry.py",
+    )
+    pe_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pe_module)
+
+    global entry
+    entry = pe_module.CustomPayrollEntry()
+    entry.name = "PE-TEST"
+    entry.employees = [object(), object()]
+
+    entry.submit()
+
+    assert slip_store["SS-0"].docstatus == 1
+    assert slip_store["SS-1"].docstatus == 1


### PR DESCRIPTION
## Summary
- automatically create salary slips when a payroll entry is submitted
- expose helper via hooks so the job runs on submit
- test salary slip generation from payroll entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687744fe10248333954ce938cea3322e