### PR TITLE
Update Payroll Entry slip creation API

### DIFF
--- a/payroll_indonesia/override/payroll_entry_functions.py
+++ b/payroll_indonesia/override/payroll_entry_functions.py
@@ -317,7 +317,7 @@ def create_salary_slips(doc, method=None, enqueue=False):
 
     try:
         create_fn = enqueue_make_salary_slips if enqueue else make_salary_slips
-        slip_names = create_fn(doc.name)
+        slip_names = create_fn(doc)
         if isinstance(slip_names, dict):
             slip_names = slip_names.get("salary_slips") or []
 

--- a/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
@@ -52,8 +52,8 @@ def test_payroll_entry_creates_salary_slips(monkeypatch):
 
     # stub hrms payroll entry functions
     hrms_mod = types.ModuleType("hrms.payroll.doctype.payroll_entry.payroll_entry")
-    def make_salary_slips(payroll_entry_name):
-        return [f"SS-{i}" for i, _ in enumerate(entry.employees)]
+    def make_salary_slips(payroll_entry):
+        return [f"SS-{i}" for i, _ in enumerate(payroll_entry.employees)]
     hrms_mod.make_salary_slips = make_salary_slips
     hrms_mod.enqueue_make_salary_slips = make_salary_slips
     sys.modules["hrms"] = types.ModuleType("hrms")


### PR DESCRIPTION
## Summary
- update `create_salary_slips` to pass the Payroll Entry doc rather than its name
- adapt salary slip tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68774c6582a083338d2c5bc9107127a3