### PR TITLE
Remove Payroll Entry hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The Payroll Indonesia module is modularly optimized to provide top performance a
 
 ## 📁 Module Structure
 
-* **📋 Payroll Entry:** Enhanced validation, automated Salary Slip integration.
+* **📋 Payroll Entry:** Enhanced validation, automated Salary Slip integration. Salary slips are generated directly from `CustomPayrollEntry.on_submit` and not via a document event hook.
 * **📃 Salary Slip:** Modular overrides for BPJS and PPh21 salary calculations.
 * **📊 Salary Structure:** Wildcard company ('%') functionality, automatic GL account mappings.
 * **👥 Employee & Auth Hooks:** Robust employee data validation, Indonesian region-specific user session integration.

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -57,9 +57,6 @@ doc_events = {
         "after_insert": "payroll_indonesia.fixtures.setup.setup_company_accounts",
         "on_update": "payroll_indonesia.fixtures.setup.setup_company_accounts",
     },
-    "Payroll Entry": {
-        "on_submit": "payroll_indonesia.override.payroll_entry_functions.create_salary_slips",
-    },
     "Payment Entry": {
         "on_submit": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.payment_hooks.on_payment_entry_submit",
     },

--- a/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
@@ -52,7 +52,9 @@ def test_payroll_entry_creates_salary_slips(monkeypatch):
 
     # stub hrms payroll entry functions
     hrms_mod = types.ModuleType("hrms.payroll.doctype.payroll_entry.payroll_entry")
+    call_counter = {"count": 0}
     def make_salary_slips(payroll_entry):
+        call_counter["count"] += 1
         return [f"SS-{i}" for i, _ in enumerate(payroll_entry.employees)]
     hrms_mod.make_salary_slips = make_salary_slips
     hrms_mod.enqueue_make_salary_slips = make_salary_slips
@@ -109,3 +111,4 @@ def test_payroll_entry_creates_salary_slips(monkeypatch):
 
     assert slip_store["SS-0"].docstatus == 1
     assert slip_store["SS-1"].docstatus == 1
+    assert call_counter["count"] == 1


### PR DESCRIPTION
## Summary
- remove doc_events hook for Payroll Entry salary slip creation
- verify salary slips are created exactly once in tests
- document the new trigger in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687753a7a6a8833386ee5281a2174919