### PR TITLE
Refactor payroll entry salary slip test

### DIFF
--- a/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_payroll_entry_salary_slips.py
@@ -100,7 +100,7 @@ def test_payroll_entry_creates_salary_slips(monkeypatch):
     pe_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(pe_module)
 
-    global entry
+
     entry = pe_module.CustomPayrollEntry()
     entry.name = "PE-TEST"
     entry.employees = [object(), object()]


### PR DESCRIPTION
## Summary
- make the `entry` variable local inside `test_payroll_entry_creates_salary_slips`
- confirm no other test modules depend on this global variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687753ab2d148333a7c0566f3038935e