### PR TITLE
Remove duplicate PPh21 deduction updates

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -78,7 +78,6 @@ class CustomSalarySlip(SalarySlip):
         self.tax = tax_amount
         self.tax_type = "TER"
 
-        self.update_pph21_row(tax_amount)
         return tax_amount
 
     def calculate_income_tax_december(self):
@@ -100,7 +99,6 @@ class CustomSalarySlip(SalarySlip):
         self.tax = tax_amount
         self.tax_type = "DECEMBER"
 
-        self.update_pph21_row(tax_amount)
         self.sync_to_annual_payroll_history(result, mode="december")
         return tax_amount
 


### PR DESCRIPTION
## Summary
- avoid calling `update_pph21_row` inside `calculate_income_tax` and `calculate_income_tax_december`
- keep deduction update during validation only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b738ee4cc8333bc1680f5b1d6eb03