### PR TITLE
feat: use December tax calc when month is 12

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -184,7 +184,13 @@ class CustomSalarySlip(SalarySlip):
                 start_date=getattr(self, "start_date", None),
                 nama_bulan=getattr(self, "bulan", None)
             )
-            
+
+            # When running for December or explicitly set to DECEMBER, use annual calculation
+            if bulan == 12 or str(getattr(self, "tax_type", "")).upper() == "DECEMBER":
+                # Ensure tax type is marked as DECEMBER before calculation
+                self.tax_type = "DECEMBER"
+                return self.calculate_income_tax_december()
+
             # Calculate taxable income
             taxable_income = self._calculate_taxable_income()
 


### PR DESCRIPTION
## Summary
- use annual PPh21 calculation when slip month is December or tax type explicitly set
- safeguard to mark tax type as DECEMBER and leverage December calculator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f373ced48833397b6a0d23a54dbe8