### PR TITLE
feat: add mobile attendance check-in

### DIFF
--- a/docs/mobile_check_in.md
+++ b/docs/mobile_check_in.md
@@ -1,0 +1,32 @@
+# Mobile Check-In API
+
+Endpoint: `/api/method/payroll_indonesia.api.attendance.mobile_check_in`
+
+## Parameters
+
+| Name       | Type  | Description               |
+|------------|-------|---------------------------|
+| `employee` | Data  | ID of the employee        |
+| `latitude` | Float | Current latitude in WGS84 |
+| `longitude`| Float | Current longitude in WGS84|
+
+## Example Request
+
+```bash
+curl -X POST https://example.com/api/method/payroll_indonesia.api.attendance.mobile_check_in \
+  -d "employee=EMP-0001" \
+  -d "latitude=-6.1754" \
+  -d "longitude=106.8272"
+```
+
+### Success `200`
+
+```json
+{"message": "Attendance marked", "name": "ATT-0001"}
+```
+
+### Out of Range `403`
+
+```json
+{"exc": "frappe.PermissionError: Check-in location too far from office"}
+```

--- a/docs/payroll_indonesia_settings.md
+++ b/docs/payroll_indonesia_settings.md
@@ -12,6 +12,8 @@ Modul ini menyimpan semua konfigurasi penggajian sesuai regulasi Indonesia seper
 | `validate_tax_status_strict`      | Check                       | Validasi `tax_status` terhadap PTKP table |
 | `salary_slip_use_component_cache` | Check                       | Aktifkan cache komponen Salary Slip |
 | `auto_queue_salary_slip`          | Check                       | Salary Slip diproses via background job |
+| `office_latitude`                 | Float                       | Koordinat latitude kantor |
+| `office_longitude`                | Float                       | Koordinat longitude kantor |
 
 ---
 

--- a/payroll_indonesia/api/__init__.py
+++ b/payroll_indonesia/api/__init__.py
@@ -1,0 +1,1 @@
+"""API endpoints for mobile integrations."""

--- a/payroll_indonesia/api/attendance.py
+++ b/payroll_indonesia/api/attendance.py
@@ -1,0 +1,47 @@
+import math
+
+import frappe
+from frappe import _
+from frappe.utils import today
+
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return distance in meters between two coordinates."""
+    r = 6371000  # Earth radius in meters
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return r * c
+
+
+@frappe.whitelist()
+def mobile_check_in(employee: str, latitude: float, longitude: float):
+    """Validate employee proximity to office and create an attendance record."""
+    settings = frappe.get_single("Payroll Indonesia Settings")
+    if not (settings.office_latitude and settings.office_longitude):
+        frappe.throw(_("Office coordinates are not set"))
+
+    distance = _haversine(
+        float(latitude),
+        float(longitude),
+        float(settings.office_latitude),
+        float(settings.office_longitude),
+    )
+    if distance > 25:
+        frappe.throw(_("Check-in location too far from office"), frappe.PermissionError)
+
+    company = frappe.db.get_value("Employee", employee, "company")
+    attendance = frappe.get_doc(
+        {
+            "doctype": "Attendance",
+            "employee": employee,
+            "company": company,
+            "status": "Present",
+            "attendance_date": today(),
+        }
+    )
+    attendance.insert(ignore_permissions=True)
+    return {"message": _("Attendance marked"), "name": attendance.name}

--- a/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
@@ -45,6 +45,18 @@
       "description": "Salary Slip diproses via background job"
     },
     {
+      "fieldname": "office_latitude",
+      "fieldtype": "Float",
+      "label": "Office Latitude",
+      "precision": 6
+    },
+    {
+      "fieldname": "office_longitude",
+      "fieldtype": "Float",
+      "label": "Office Longitude",
+      "precision": 6
+    },
+    {
       "fieldname": "bpjs_settings_section",
       "fieldtype": "Section Break",
       "label": "BPJS Settings"


### PR DESCRIPTION
## Summary
- allow storing office GPS coordinates in Payroll Indonesia Settings
- add mobile_check_in API for GPS-based attendance within 25 meters
- document settings and mobile API usage

## Testing
- `pip install --quiet frappe erpnext` *(failed: Could not find a version that satisfies the requirement frappe)*
- `pip install --quiet pytest` *(failed: No matching distribution found for pytest)*
- `pytest -q` *(command not found: pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68afed5666e88333b096dbb7c82cb453