### PR TITLE
Handle half-day absence deductions

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -107,11 +107,20 @@ class CustomSalarySlip(SalarySlip):
     # -------------------------
     # Absence deduction
     # -------------------------
-    def _get_unpaid_absent_days(self) -> int:
-        """Count attendance records that should result in salary deduction."""
+    def _get_unpaid_absent_days(self) -> float:
+        """Count attendance records that should result in salary deduction.
+
+        Supports half-day deductions by returning a float. The following
+        statuses are considered:
+
+        * ``Absent`` – full day (1.0)
+        * ``Half Day`` – half day (0.5)
+        * ``Izin``, ``Sakit`` and ``Tanpa Keterangan`` – full day (1.0)
+        * ``On Leave`` and ``Work From Home`` – paid (0.0)
+        """
         try:
             if not (getattr(self, "employee", None) and getattr(self, "start_date", None) and getattr(self, "end_date", None)):
-                return 0
+                return 0.0
             rows = frappe.get_all(
                 "Employee Attendance",
                 filters={
@@ -121,10 +130,18 @@ class CustomSalarySlip(SalarySlip):
                 },
                 fields=["status"],
             )
-            unpaid = {"Izin", "Sakit", "Tanpa Keterangan"}
-            return sum(1 for r in rows if r.get("status") in unpaid)
+            full_day = {"Izin", "Sakit", "Tanpa Keterangan", "Absent"}
+            half_day = {"Half Day"}
+            days = 0.0
+            for r in rows:
+                status = r.get("status")
+                if status in full_day:
+                    days += 1.0
+                elif status in half_day:
+                    days += 0.5
+            return days
         except Exception:
-            return 0
+            return 0.0
 
     def _insert_absence_deduction(self):
         days = self._get_unpaid_absent_days()
@@ -134,7 +151,7 @@ class CustomSalarySlip(SalarySlip):
             daily_rate = flt(getattr(self, "base", 0)) / flt(getattr(self, "total_working_days", 1) or 1)
         except Exception:
             daily_rate = 0
-        amount = days * daily_rate
+        amount = flt(days) * daily_rate
         if not getattr(self, "deductions", None):
             self.deductions = []
         self.deductions.append(frappe._dict({"salary_component": "Absence Deduction", "amount": amount}))
@@ -751,7 +768,7 @@ def on_cancel(doc, method=None):
 
 
 def recalculate_slip_deductions(doc, method=None):
-    """Recalculate salary slips when attendance changes."""
+    """Recalculate salary slips when attendance changes, including fractional days."""
     try:
         slips = frappe.get_all(
             "Salary Slip",

--- a/payroll_indonesia/tests/test_absence_deduction.py
+++ b/payroll_indonesia/tests/test_absence_deduction.py
@@ -5,8 +5,17 @@ import frappe
 from payroll_indonesia.override.salary_slip import CustomSalarySlip
 
 
-@pytest.mark.parametrize("status", ["Izin", "Sakit", "Tanpa Keterangan"])
-def test_absence_deduction(monkeypatch, status):
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("Izin", 100.0),
+        ("Sakit", 100.0),
+        ("Tanpa Keterangan", 100.0),
+        ("Absent", 100.0),
+        ("Half Day", 50.0),
+    ],
+)
+def test_absence_deduction(monkeypatch, status, expected):
     slip = CustomSalarySlip()
     slip.name = "SS-TEST"
     slip.employee = "EMP-001"
@@ -38,5 +47,5 @@ def test_absence_deduction(monkeypatch, status):
     ]
     assert deduction, "Absence deduction row not found"
     amount = deduction[0]["amount"] if isinstance(deduction[0], dict) else deduction[0].amount
-    assert amount == pytest.approx(100.0)
+    assert amount == pytest.approx(expected)
 


### PR DESCRIPTION
## Summary
- Treat 'Absent' as a full unpaid day and 'Half Day' as a half unpaid day
- Deduct salary using fractional day counts and recalc slips when attendance changes
- Test full-day and half-day absence deductions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b449f477f08333bff4ada1d134c9ed