### PR TITLE
feat: add status to mobile check-in

### DIFF
--- a/docs/mobile_check_in.md
+++ b/docs/mobile_check_in.md
@@ -9,6 +9,9 @@ Endpoint: `/api/method/payroll_indonesia.api.attendance.mobile_check_in`
 | `employee` | Data  | ID of the employee        |
 | `latitude` | Float | Current latitude in WGS84 |
 | `longitude`| Float | Current longitude in WGS84|
+| `status`   | Data  | Optional attendance status. Defaults to `Present`. |
+
+Valid values: `Present`, `Absent`, `Half Day`, `On Leave`, `Work From Home`, `Holiday`.
 
 ## Example Request
 
@@ -16,7 +19,8 @@ Endpoint: `/api/method/payroll_indonesia.api.attendance.mobile_check_in`
 curl -X POST https://example.com/api/method/payroll_indonesia.api.attendance.mobile_check_in \
   -d "employee=EMP-0001" \
   -d "latitude=-6.1754" \
-  -d "longitude=106.8272"
+  -d "longitude=106.8272" \
+  -d "status=Work From Home"
 ```
 
 ### Success `200`

--- a/payroll_indonesia/api/attendance.py
+++ b/payroll_indonesia/api/attendance.py
@@ -1,8 +1,18 @@
 import math
+from enum import Enum
 
 import frappe
 from frappe import _
 from frappe.utils import today
+
+
+class AttendanceStatus(str, Enum):
+    PRESENT = "Present"
+    ABSENT = "Absent"
+    HALF_DAY = "Half Day"
+    ON_LEAVE = "On Leave"
+    WORK_FROM_HOME = "Work From Home"
+    HOLIDAY = "Holiday"
 
 
 def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -18,7 +28,9 @@ def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 
 
 @frappe.whitelist()
-def mobile_check_in(employee: str, latitude: float, longitude: float):
+def mobile_check_in(
+    employee: str, latitude: float, longitude: float, status: str | None = None
+):
     """Validate employee proximity to office and create an attendance record."""
     settings = frappe.get_single("Payroll Indonesia Settings")
     if not (settings.office_latitude and settings.office_longitude):
@@ -34,12 +46,18 @@ def mobile_check_in(employee: str, latitude: float, longitude: float):
         frappe.throw(_("Check-in location too far from office"), frappe.PermissionError)
 
     company = frappe.db.get_value("Employee", employee, "company")
+    status_value = status or AttendanceStatus.PRESENT.value
+    try:
+        status_enum = AttendanceStatus(status_value)
+    except ValueError:
+        frappe.throw(_("Invalid status"))
+
     attendance = frappe.get_doc(
         {
             "doctype": "Attendance",
             "employee": employee,
             "company": company,
-            "status": "Present",
+            "status": status_enum.value,
             "attendance_date": today(),
         }
     )

--- a/payroll_indonesia/tests/test_mobile_check_in.py
+++ b/payroll_indonesia/tests/test_mobile_check_in.py
@@ -1,0 +1,66 @@
+import types
+
+import frappe
+
+# Ensure required frappe utilities exist before importing module under test
+frappe._ = lambda msg: msg
+frappe.utils.today = lambda: "2024-01-01"
+frappe.whitelist = lambda *a, **k: (lambda f: f)
+frappe.get_single = lambda *a, **k: None
+
+from payroll_indonesia.api.attendance import mobile_check_in
+
+
+def test_mobile_check_in_work_from_home(monkeypatch):
+    """mobile_check_in should accept Work From Home status"""
+
+    # Stub configuration and db functions
+    monkeypatch.setattr(
+        frappe,
+        "get_single",
+        lambda name: types.SimpleNamespace(office_latitude=0.0, office_longitude=0.0),
+    )
+    monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Test Company")
+
+    inserted = {}
+
+    class DummyDoc:
+        def __init__(self, data):
+            self.data = data
+            self.name = "ATT-0001"
+
+        def insert(self, ignore_permissions=False):
+            inserted.update(self.data)
+
+    monkeypatch.setattr(frappe, "get_doc", lambda data: DummyDoc(data))
+
+    result = mobile_check_in("EMP-0001", 0.0, 0.0, status="Work From Home")
+
+    assert inserted["status"] == "Work From Home"
+    assert result["name"] == "ATT-0001"
+
+
+def test_mobile_check_in_default_status(monkeypatch):
+    monkeypatch.setattr(
+        frappe,
+        "get_single",
+        lambda name: types.SimpleNamespace(office_latitude=0.0, office_longitude=0.0),
+    )
+    monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Test Company")
+
+    captured = {}
+
+    class DummyDoc:
+        def __init__(self, data):
+            self.data = data
+            self.name = "ATT-0002"
+
+        def insert(self, ignore_permissions=False):
+            captured.update(self.data)
+
+    monkeypatch.setattr(frappe, "get_doc", lambda data: DummyDoc(data))
+
+    result = mobile_check_in("EMP-0001", 0.0, 0.0)
+
+    assert captured["status"] == "Present"
+    assert result["name"] == "ATT-0002"


### PR DESCRIPTION
## Summary
- allow mobile check-in to specify attendance status
- document optional status parameter and supported values
- test mobile check-in including Work From Home and default status

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b449f6edec833381134d42bcc4ef34