### PR TITLE
Show all Payroll Indonesia doctypes in workspace shortcuts

### DIFF
--- a/payroll_indonesia/fixtures/workspace.json
+++ b/payroll_indonesia/fixtures/workspace.json
@@ -6,7 +6,7 @@
   "icon": "income",
   "module": "Payroll Indonesia",
   "content_type": "Blocks",
-  "content": "[{\"id\":\"hdr1\",\"type\":\"header\",\"data\":{\"text\":\"Payroll Indonesia\",\"col\":12}},{\"id\":\"s1\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Slip\",\"col\":3}},{\"id\":\"s2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Payroll Entry\",\"col\":3}},{\"id\":\"s3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Register\",\"col\":3}},{\"id\":\"s4\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Annual Payroll History\",\"col\":3}},{\"id\":\"spacer1\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr2\",\"type\":\"header\",\"data\":{\"text\":\"Masters\",\"col\":12}},{\"id\":\"c1\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Employee\",\"link_to\":\"Employee\",\"type\":\"DocType\"},{\"label\":\"Salary Component\",\"link_to\":\"Salary Component\",\"type\":\"DocType\"}]}},{\"id\":\"spacer2\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr3\",\"type\":\"header\",\"data\":{\"text\":\"Payroll\",\"col\":12}},{\"id\":\"c2\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Payroll Entry\",\"link_to\":\"Payroll Entry\",\"type\":\"DocType\"},{\"label\":\"Salary Slip\",\"link_to\":\"Salary Slip\",\"type\":\"DocType\"},{\"label\":\"Annual Payroll History\",\"link_to\":\"Annual Payroll History\",\"type\":\"DocType\"}]}},{\"id\":\"spacer3\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr4\",\"type\":\"header\",\"data\":{\"text\":\"Incentives\",\"col\":12}},{\"id\":\"c3\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Additional Salary\",\"link_to\":\"Additional Salary\",\"type\":\"DocType\"},{\"label\":\"Salary Structure Assignment\",\"link_to\":\"Salary Structure Assignment\",\"type\":\"DocType\"}]}},{\"id\":\"spacer4\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr5\",\"type\":\"header\",\"data\":{\"text\":\"Accounting\",\"col\":12}},{\"id\":\"c4\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Journal Entry\",\"link_to\":\"Journal Entry\",\"type\":\"DocType\"},{\"label\":\"Payroll Indonesia Settings\",\"link_to\":\"Payroll Indonesia Settings\",\"type\":\"DocType\"}]}},{\"id\":\"spacer5\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr6\",\"type\":\"header\",\"data\":{\"text\":\"Reports\",\"col\":12}},{\"id\":\"c5\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"General Ledger\",\"link_to\":\"General Ledger\",\"type\":\"Report\"},{\"label\":\"Bank Reconciliation Statement\",\"link_to\":\"Bank Reconciliation Statement\",\"type\":\"Report\"}]}},{\"id\":\"c6\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Salary Register\",\"link_to\":\"Salary Register\",\"type\":\"Report\"},{\"label\":\"PPh21 Report\",\"link_to\":\"PPh21 Report\",\"type\":\"Report\"},{\"label\":\"BPJS Report\",\"link_to\":\"BPJS Report\",\"type\":\"Report\"}]}},{\"id\":\"spacer6\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr7\",\"type\":\"header\",\"data\":{\"text\":\"Custom Documents\",\"col\":12}},{\"id\":\"c7\",\"type\":\"card\",\"data\":{\"col\":12,\"links\":[{\"label\":\"Annual Payroll History\",\"link_to\":\"Annual Payroll History\",\"type\":\"DocType\"},{\"label\":\"Employee Attendance\",\"link_to\":\"Employee Attendance\",\"type\":\"DocType\"},{\"label\":\"PTKP Table\",\"link_to\":\"PTKP Table\",\"type\":\"DocType\"},{\"label\":\"Office Location\",\"link_to\":\"Office Location\",\"type\":\"DocType\"},{\"label\":\"TER Bracket Table\",\"link_to\":\"TER Bracket Table\",\"type\":\"DocType\"},{\"label\":\"TER Mapping Table\",\"link_to\":\"TER Mapping Table\",\"type\":\"DocType\"},{\"label\":\"Payroll Indonesia Settings\",\"link_to\":\"Payroll Indonesia Settings\",\"type\":\"DocType\"},{\"label\":\"Annual Payroll History Child\",\"link_to\":\"Annual Payroll History Child\",\"type\":\"DocType\"}]}}]",
+  "content": "[{\"id\":\"hdr1\",\"type\":\"header\",\"data\":{\"text\":\"Payroll Indonesia\",\"col\":12}},{\"id\":\"s1\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Slip\",\"col\":3}},{\"id\":\"s2\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Payroll Entry\",\"col\":3}},{\"id\":\"s3\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Salary Register\",\"col\":3}},{\"id\":\"s4\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Annual Payroll History\",\"col\":3}},{\"id\":\"s5\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Annual Payroll History Child\",\"col\":3}},{\"id\":\"s6\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Employee Attendance\",\"col\":3}},{\"id\":\"s7\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Office Location\",\"col\":3}},{\"id\":\"s8\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"PTKP Table\",\"col\":3}},{\"id\":\"s9\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Payroll Indonesia Settings\",\"col\":3}},{\"id\":\"s10\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"TER Bracket Table\",\"col\":3}},{\"id\":\"s11\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"TER Mapping Table\",\"col\":3}},{\"id\":\"spacer1\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr2\",\"type\":\"header\",\"data\":{\"text\":\"Masters\",\"col\":12}},{\"id\":\"c1\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Employee\",\"link_to\":\"Employee\",\"type\":\"DocType\"},{\"label\":\"Salary Component\",\"link_to\":\"Salary Component\",\"type\":\"DocType\"}]}},{\"id\":\"spacer2\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr3\",\"type\":\"header\",\"data\":{\"text\":\"Payroll\",\"col\":12}},{\"id\":\"c2\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Payroll Entry\",\"link_to\":\"Payroll Entry\",\"type\":\"DocType\"},{\"label\":\"Salary Slip\",\"link_to\":\"Salary Slip\",\"type\":\"DocType\"},{\"label\":\"Annual Payroll History\",\"link_to\":\"Annual Payroll History\",\"type\":\"DocType\"}]}},{\"id\":\"spacer3\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr4\",\"type\":\"header\",\"data\":{\"text\":\"Incentives\",\"col\":12}},{\"id\":\"c3\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Additional Salary\",\"link_to\":\"Additional Salary\",\"type\":\"DocType\"},{\"label\":\"Salary Structure Assignment\",\"link_to\":\"Salary Structure Assignment\",\"type\":\"DocType\"}]}},{\"id\":\"spacer4\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr5\",\"type\":\"header\",\"data\":{\"text\":\"Accounting\",\"col\":12}},{\"id\":\"c4\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Journal Entry\",\"link_to\":\"Journal Entry\",\"type\":\"DocType\"},{\"label\":\"Payroll Indonesia Settings\",\"link_to\":\"Payroll Indonesia Settings\",\"type\":\"DocType\"}]}},{\"id\":\"spacer5\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr6\",\"type\":\"header\",\"data\":{\"text\":\"Reports\",\"col\":12}},{\"id\":\"c5\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"General Ledger\",\"link_to\":\"General Ledger\",\"type\":\"Report\"},{\"label\":\"Bank Reconciliation Statement\",\"link_to\":\"Bank Reconciliation Statement\",\"type\":\"Report\"}]}},{\"id\":\"c6\",\"type\":\"card\",\"data\":{\"col\":6,\"links\":[{\"label\":\"Salary Register\",\"link_to\":\"Salary Register\",\"type\":\"Report\"},{\"label\":\"PPh21 Report\",\"link_to\":\"PPh21 Report\",\"type\":\"Report\"},{\"label\":\"BPJS Report\",\"link_to\":\"BPJS Report\",\"type\":\"Report\"}]}},{\"id\":\"spacer6\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"hdr7\",\"type\":\"header\",\"data\":{\"text\":\"Custom Documents\",\"col\":12}},{\"id\":\"c7\",\"type\":\"card\",\"data\":{\"col\":12,\"links\":[{\"label\":\"Annual Payroll History\",\"link_to\":\"Annual Payroll History\",\"type\":\"DocType\"},{\"label\":\"Employee Attendance\",\"link_to\":\"Employee Attendance\",\"type\":\"DocType\"},{\"label\":\"PTKP Table\",\"link_to\":\"PTKP Table\",\"type\":\"DocType\"},{\"label\":\"Office Location\",\"link_to\":\"Office Location\",\"type\":\"DocType\"},{\"label\":\"TER Bracket Table\",\"link_to\":\"TER Bracket Table\",\"type\":\"DocType\"},{\"label\":\"TER Mapping Table\",\"link_to\":\"TER Mapping Table\",\"type\":\"DocType\"},{\"label\":\"Payroll Indonesia Settings\",\"link_to\":\"Payroll Indonesia Settings\",\"type\":\"DocType\"},{\"label\":\"Annual Payroll History Child\",\"link_to\":\"Annual Payroll History Child\",\"type\":\"DocType\"}]}}]",
   "public": 1,
   "sequence": 10,
   "is_hidden": 0,
@@ -32,6 +32,41 @@
     {
       "label": "Annual Payroll History",
       "link_to": "Annual Payroll History",
+      "type": "DocType"
+    },
+    {
+      "label": "Annual Payroll History Child",
+      "link_to": "Annual Payroll History Child",
+      "type": "DocType"
+    },
+    {
+      "label": "Employee Attendance",
+      "link_to": "Employee Attendance",
+      "type": "DocType"
+    },
+    {
+      "label": "Office Location",
+      "link_to": "Office Location",
+      "type": "DocType"
+    },
+    {
+      "label": "PTKP Table",
+      "link_to": "PTKP Table",
+      "type": "DocType"
+    },
+    {
+      "label": "Payroll Indonesia Settings",
+      "link_to": "Payroll Indonesia Settings",
+      "type": "DocType"
+    },
+    {
+      "label": "TER Bracket Table",
+      "link_to": "TER Bracket Table",
+      "type": "DocType"
+    },
+    {
+      "label": "TER Mapping Table",
+      "link_to": "TER Mapping Table",
       "type": "DocType"
     }
   ],


### PR DESCRIPTION
### Motivation
- Make all custom doctypes from the Payroll Indonesia module visible and directly accessible from the module workspace.
- Ensure the workspace UI reflects the module's custom documents so users can navigate to them quickly.

### Description
- Updated `payroll_indonesia/fixtures/workspace.json` to add shortcut blocks for the module doctypes: `Annual Payroll History Child`, `Employee Attendance`, `Office Location`, `PTKP Table`, `Payroll Indonesia Settings`, `TER Bracket Table`, and `TER Mapping Table`.
- Synchronized the top-level `shortcuts` array in `workspace.json` to include the same doctypes so the workspace blocks and shortcut list match.
- Kept the existing workspace layout and content formatting while inserting the new shortcut blocks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b26c572cc8333ad597f9a377c6d71)