### PR TITLE
Enforce full BPJS component selection in salary structure validation

### DIFF
--- a/payroll_indonesia/utils/validate_salary_structure.py
+++ b/payroll_indonesia/utils/validate_salary_structure.py
@@ -26,10 +26,8 @@ def validate_salary_structure_required_components(doc, method):
     earning_names = [e.salary_component for e in getattr(doc, "earnings", [])]
     deduction_names = [d.salary_component for d in getattr(doc, "deductions", [])]
 
-    found_bpjs = (
-        any(comp in earning_names for comp in bpjs_employer) or
-        any(comp in deduction_names for comp in bpjs_employee)
-    )
+    all_bpjs_components = set(bpjs_employer + bpjs_employee + contra_bpjs_employer)
+    found_bpjs = any(comp in all_bpjs_components for comp in earning_names + deduction_names)
 
     if found_bpjs:
         missing_bpjs_employer = [comp for comp in bpjs_employer if comp not in earning_names]


### PR DESCRIPTION
### Motivation
- Memastikan validasi salary structure dipicu saat terdapat salah satu komponen BPJS (termasuk `Contra`) di `earnings` atau `deductions` sehingga tidak boleh memilih komponen BPJS secara parsial.
- Perbaikan ini menutup celah di mana pemeriksaan sebelumnya hanya melihat employer di `earnings` dan employee di `deductions` saja.
- Mencegah konfigurasi yang tidak lengkap yang dapat merusak perhitungan atau laporan BPJS.

### Description
- Ubah fungsi `validate_salary_structure_required_components` untuk membentuk `all_bpjs_components` yang mencakup employer, employee, dan contra BPJS.
- Ganti kondisi `found_bpjs` dengan pengecekan apakah ada komponen dari `all_bpjs_components` dalam gabungan nama komponen `earnings` dan `deductions`.
- Logika pengumpulan komponen yang hilang (`missing_bpjs_employer`, `missing_bpjs_employee`, `missing_contra`, `missing_deduction`) dan pesan error via `frappe.throw` tetap dipertahankan.

### Testing
- Tidak ada tes otomatis yang dijalankan selama rollout ini.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964635630f08333bacb6d39b1ffdf4f)