### PR TITLE
Relax BPJS salary structure validation

### DIFF
--- a/payroll_indonesia/utils/validate_salary_structure.py
+++ b/payroll_indonesia/utils/validate_salary_structure.py
@@ -6,26 +6,8 @@ def validate_salary_structure_required_components(doc, method):
     
     missing_components = []
     
-    # Validasi BPJS Kesehatan
-    if "BPJS Kesehatan Employer" in earning_names or "BPJS Kesehatan Employee" in deduction_names:
-        if "BPJS Kesehatan Employer" not in earning_names:
-            missing_components.append("BPJS Kesehatan Employer")
-        if "BPJS Kesehatan Employee" not in deduction_names:
-            missing_components.append("BPJS Kesehatan Employee")
-    
-    # Validasi BPJS JHT
-    if "BPJS JHT Employer" in earning_names or "BPJS JHT Employee" in deduction_names:
-        if "BPJS JHT Employer" not in earning_names:
-            missing_components.append("BPJS JHT Employer")
-        if "BPJS JHT Employee" not in deduction_names:
-            missing_components.append("BPJS JHT Employee")
-    
-    # Validasi BPJS JP
-    if "BPJS JP Employer" in earning_names or "BPJS JP Employee" in deduction_names:
-        if "BPJS JP Employer" not in earning_names:
-            missing_components.append("BPJS JP Employer")
-        if "BPJS JP Employee" not in deduction_names:
-            missing_components.append("BPJS JP Employee")
+    # Komponen BPJS bersifat opsional. Tidak memaksa pasangan employer/employee,
+    # sehingga Salary Structure bisa dibuat secara parsial sesuai kebutuhan.
     
     # Validasi PPh 21 - hanya jika ada komponen taxable
     has_taxable = any(


### PR DESCRIPTION
### Motivation
- The `validate_salary_structure_required_components` hook enforced that BPJS employer/employee pairs must both exist, preventing saving of partial salary structures and causing validation errors.

### Description
- Remove strict checks that required matching BPJS Employer/Employee components so BPJS components are now optional and salary structures can be defined partially.
- Preserve the existing PPh 21 validation that requires `Biaya Jabatan` and `PPh 21` when taxable earnings are present.
- Update the function comment in `validate_salary_structure_required_components` to document the relaxed BPJS behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696750ddce9883339b7d0b0e9fd4b426)